### PR TITLE
Cache LagCompensatedCount in EntityClassData

### DIFF
--- a/LiteEntitySystem/EntityLogic.cs
+++ b/LiteEntitySystem/EntityLogic.cs
@@ -53,6 +53,7 @@ namespace LiteEntitySystem
         private readonly byte[] _history;
         private readonly EntityFieldInfo[] _lagCompensatedFields;
         private readonly int _lagCompensatedSize;
+        private readonly int _lagCompensatedCount;
         private int _filledHistory;
         private bool _lagCompensationEnabled;
 
@@ -67,7 +68,7 @@ namespace LiteEntitySystem
             int historyOffset = ((tick % maxHistory)+1)*_lagCompensatedSize;
             fixed (byte* history = _history)
             {
-                for (int i = 0; i < _lagCompensatedFields.Length; i++)
+                for (int i = 0; i < _lagCompensatedCount; i++)
                 {
                     ref var field = ref _lagCompensatedFields[i];
                     field.TypeProcessor.WriteTo(this, field.Offset, history + historyOffset);
@@ -94,7 +95,7 @@ namespace LiteEntitySystem
 
             fixed (byte* history = _history)
             {
-                for (int i = 0; i < _lagCompensatedFields.Length; i++)
+                for (int i = 0; i < _lagCompensatedCount; i++)
                 {
                     ref var field = ref _lagCompensatedFields[i];
                     field.TypeProcessor.LoadHistory(
@@ -122,7 +123,7 @@ namespace LiteEntitySystem
             int historyOffset = 0;
             fixed (byte* history = _history)
             {
-                for (int i = 0; i < _lagCompensatedFields.Length; i++)
+                for (int i = 0; i < _lagCompensatedCount; i++)
                 {
                     ref var field = ref _lagCompensatedFields[i];
                     field.TypeProcessor.SetFrom(this, field.Offset, history + historyOffset);
@@ -304,6 +305,7 @@ namespace LiteEntitySystem
             {
                 _history = new byte[((byte)EntityManager.MaxHistorySize+1) * _lagCompensatedSize];
                 _lagCompensatedFields = classData.LagCompensatedFields;
+                _lagCompensatedCount = classData.LagCompensatedCount;
             }
         }
     }

--- a/LiteEntitySystem/Internal/EntityClassData.cs
+++ b/LiteEntitySystem/Internal/EntityClassData.cs
@@ -48,6 +48,7 @@ namespace LiteEntitySystem.Internal
         public readonly int InterpolatedCount;
         public readonly EntityFieldInfo[] LagCompensatedFields;
         public readonly int LagCompensatedSize;
+        public readonly int LagCompensatedCount;
         public readonly bool UpdateOnClient;
         public readonly bool IsUpdateable;
         public readonly bool IsLocalOnly;
@@ -117,6 +118,7 @@ namespace LiteEntitySystem.Internal
             PredictedSize = 0;
             FixedFieldsSize = 0;
             LagCompensatedSize = 0;
+            LagCompensatedCount = 0;
             InterpolatedCount = 0;
             InterpolatedFieldsSize = 0;
 
@@ -269,6 +271,7 @@ namespace LiteEntitySystem.Internal
             FieldsCount = Fields.Length;
             FieldsFlagsSize = (FieldsCount-1) / 8 + 1;
             LagCompensatedFields = lagCompensatedFields.ToArray();
+            LagCompensatedCount = LagCompensatedFields.Length;
             RemoteCallsClient = new MethodCallDelegate[RpcOffsets.Length];
             RemoteCallsServer = new Delegate[RpcOffsets.Length];
 


### PR DESCRIPTION
Cached `LagCompensatedCount` as `readonly int` in `EntityClassData` (already caching `InterpolatedCount` and `FieldsCount` in same location).

Updated `EntityLogic` to use `LagCompensatedCount` rather than recalculating the length every time.