### PR TITLE
Fix for SharedScriptableObject serialization

### DIFF
--- a/LiteEntitySystem/Extensions/SharedScriptableObject.cs
+++ b/LiteEntitySystem/Extensions/SharedScriptableObject.cs
@@ -107,11 +107,10 @@ namespace LiteEntitySystem.Extensions
         //INetSerializable
         public virtual void Serialize(NetDataWriter writer)
         {
-            if (_resourcePaths == null || _resourcePaths.Length == 0)
-                return;
-            writer.Put((ushort)_resourcePaths.Length);
-            for (int i = 0; i < _resourcePaths.Length; i++)
-                _resourcePaths[i].Serialize(writer);
+            ushort resourcesCount = (ushort)(_resourcePaths?.Length ?? 0);
+            writer.Put(resourcesCount);
+            for (int i = 0; i < resourcesCount; i++)
+                _resourcePaths![i].Serialize(writer);
             writer.Put(_serializedName);
         }
 


### PR DESCRIPTION
Fixes serialization of `SharedScriptableObject` in case it has no resources specified.