### PR TITLE
Event-driven SyncVar updates 

### DIFF
--- a/LiteEntitySystem/Extensions/SyncNetSerializable.cs
+++ b/LiteEntitySystem/Extensions/SyncNetSerializable.cs
@@ -36,16 +36,7 @@ namespace LiteEntitySystem.Extensions
                 OnSyncRequested();
             }
         }
-
-        private static RemoteCallSpan<byte> _initAction;
-
-        private readonly Func<T> _constructor;
-
-        public SyncNetSerializable(Func<T> constructor)
-        {
-            _constructor = constructor;
-        }
-
+        
         protected internal override void RegisterRPC(ref SyncableRPCRegistrator r)
         {
             r.CreateClientAction(this, Init, ref _initAction);
@@ -82,6 +73,8 @@ namespace LiteEntitySystem.Extensions
         {
             ushort origSize = BitConverter.ToUInt16(data); // uncompressed size
 
+            var oldValue = _value;
+            
             if (CompressionBuffer == null || CompressionBuffer.Length < origSize)
                 CompressionBuffer = new byte[origSize];
             LZ4Codec.Decode(data[2..], new Span<byte>(CompressionBuffer));

--- a/LiteEntitySystem/SyncVar.cs
+++ b/LiteEntitySystem/SyncVar.cs
@@ -4,6 +4,7 @@ using LiteEntitySystem.Internal;
 
 namespace LiteEntitySystem
 {
+    
     [Flags]
     public enum SyncFlags : byte
     {
@@ -38,9 +39,26 @@ namespace LiteEntitySystem
             OnSyncExecutionOrder = executionOrder;
         }
     }
+    
+    public class SyncVarChangedEventArgs<T> : EventArgs
+    {
+        public T OldValue { get; }
+        public T NewValue { get; }
+
+        public SyncVarChangedEventArgs(T oldValue, T newValue)
+        {
+            OldValue = oldValue;
+            NewValue = newValue;
+        }
+    }
+    
+    public interface INotifySyncVarChanged<T>
+    {
+        event EventHandler<SyncVarChangedEventArgs<T>> ValueChanged;
+    }
 
     [StructLayout(LayoutKind.Sequential)]
-    public struct SyncVar<T> : IEquatable<T>, IEquatable<SyncVar<T>> where T : unmanaged
+    public struct SyncVar<T> : INotifySyncVarChanged<T>, IEquatable<T>, IEquatable<SyncVar<T>> where T : unmanaged
     {
         private T _value;
         internal ushort FieldId;
@@ -48,16 +66,23 @@ namespace LiteEntitySystem
         
         internal void SetDirect(T value) => _value = value;
         
+        public event EventHandler<SyncVarChangedEventArgs<T>> ValueChanged;
+        
         public T Value
         {
             get => _value;
             set
             {
                 if (Container != null && !Utils.FastEquals(ref value, ref _value))
+                {
                     Container.EntityManager.EntityFieldChanged(Container, FieldId, ref value);
+                    ValueChanged?.Invoke(this, new SyncVarChangedEventArgs<T>(_value, value));
+                }
+
                 _value = value;
             }
         }
+        
 
         internal void Init(InternalEntity container, ushort fieldId)
         {
@@ -102,5 +127,6 @@ namespace LiteEntitySystem
         public bool Equals(T v) => Utils.FastEquals(ref _value, ref v);
         
         public bool Equals(SyncVar<T> tv) => Utils.FastEquals(ref _value, ref tv._value);
+        
     }
 }

--- a/LiteEntitySystem/SyncVar.cs
+++ b/LiteEntitySystem/SyncVar.cs
@@ -73,12 +73,11 @@ namespace LiteEntitySystem
             get => _value;
             set
             {
-                if (Container != null && !Utils.FastEquals(ref value, ref _value))
+                if (!Utils.FastEquals(ref value, ref _value))
                 {
-                    Container.EntityManager.EntityFieldChanged(Container, FieldId, ref value);
+                    Container?.EntityManager.EntityFieldChanged(Container, FieldId, ref value);
                     ValueChanged?.Invoke(this, new SyncVarChangedEventArgs<T>(_value, value));
                 }
-
                 _value = value;
             }
         }

--- a/LiteEntitySystem/SyncableField.cs
+++ b/LiteEntitySystem/SyncableField.cs
@@ -75,4 +75,10 @@ namespace LiteEntitySystem
             }
         }
     }
+    
+    public abstract class SyncableField<T> : SyncableField, INotifySyncVarChanged<T>
+    {
+        public abstract event EventHandler<SyncVarChangedEventArgs<T>> ValueChanged;
+        public abstract T Value { get; set; }
+    }
 }


### PR DESCRIPTION
Draft implementation for event-driven SyncVar updates.

Added SyncVarChangedEventArgs for old/new values.
Implemented INotifySyncVarChanged<T> to streamline change notifications (currently limited to unmanaged SyncVar<T> with bind).

As example I've refactored SyncVary<> and SyncNetSerializable and SyncString  and raise ValueChanged events as needed for my project.

This is a preliminary approach to make SyncVar updates easier for developers. Since SyncVar<T> only works with bind/unmanaged types. Feedback is welcome.

Example:

```csharp
using UnityEngine;
using LiteEntitySystem;
using LiteEntitySystem.Extensions;

[EntityFlags(EntityFlags.UpdateOnClient)]
public class SimpleEntity : EntityLogic
{
    private static SyncVar<int> _counter;
    private readonly SyncString _message = new();

    protected override void OnConstructed()
    {
        base.OnConstructed();
        
        // Only clients subscribe to changes
        if (IsClient)
        {
            _counter.ValueChanged += (sender, args) =>
            {
                Debug.Log($"Counter changed from {args.OldValue} to {args.NewValue}");
            };

            _message.ValueChanged += (sender, args) =>
            {
                Debug.Log($"Message changed from '{args.OldValue}' to '{args.NewValue}'");
            };
        }
    }

    protected override void Update()
    {
        if (IsServer)
        {
            // Increment counter
            _counter.Value++;

            // Update message
            _message.Value = $"Server Counter: {_counter.Value}";
        }
    }
}
```



