### PR TITLE
added registration for nested SyncableFields

### DIFF
--- a/LiteEntitySystem/EntityManager.cs
+++ b/LiteEntitySystem/EntityManager.cs
@@ -299,7 +299,7 @@ namespace LiteEntitySystem
         {
             ref var classData = ref ClassDataDict[entity.ClassId];
             foreach (EntityFieldInfo fi in classData.Fields)
-                resultPrinter.PrintFieldInfo(fi.Name, fi.TypeProcessor.ToString(entity, fi.Offset));
+                resultPrinter.PrintFieldInfo(fi.Name, fi.TypeProcessor.ToString(entity, fi.Offsets));
         }
 
         /// <summary>

--- a/LiteEntitySystem/Internal/EntityClassData.cs
+++ b/LiteEntitySystem/Internal/EntityClassData.cs
@@ -1,37 +1,72 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using ImGuiGodot.Internal;
 
 namespace LiteEntitySystem.Internal
 {
+    /// <summary>
+    /// Holds metadata for a SyncableField, including its relationship to a parent container
+    /// and the relative offset of the field within that container.
+    /// </summary>
     internal struct SyncableFieldInfo
     {
-        public readonly int Offset;
+        /// <summary>
+        /// For debug: the fully qualified name (e.g. "Entity-MovementComponent").
+        /// </summary>
+        public readonly string Name;
+
+        /// <summary>
+        /// Absolute byte offset of the containing object (entity or parent SyncableField) within the root InternalEntity.
+        /// </summary>
+        // public readonly int ParentOffset;
+
+        /// <summary>
+        /// Byte offset map to this SyncableField within its parent InternalEntity.
+        /// </summary>
+        public readonly int[] Offsets;
+
+        /// <summary>
+        /// SyncFlags controlling rollback, prediction, interpolation, etc.
+        /// </summary>
         public readonly SyncFlags Flags;
+
+        /// <summary>
+        /// Offset into the RPC table (initialized later).
+        /// </summary>
         public ushort RPCOffset;
 
-        public SyncableFieldInfo(int offset, SyncFlags executeFlags)
+        /// <summary>
+        /// Constructs a new SyncableFieldInfo.
+        /// </summary>
+        /// <param name="name">Debug name of the field.</param>
+        /// <param name="parentOffset">Absolute offset of the parent container.</param>
+        /// <param name="offset">Relative offset within the parent container.</param>
+        /// <param name="flags">SyncFlags for this field.</param>
+        public SyncableFieldInfo(string name, int[] offsets, SyncFlags flags)
         {
-            Offset = offset;
-            Flags = executeFlags;
+            Name = name;
+            Offsets = offsets;
+            Flags = flags;
             RPCOffset = ushort.MaxValue;
         }
     }
-    
+
+
     internal readonly struct RpcFieldInfo
     {
-        public readonly int SyncableOffset;
+        public readonly int[] SyncableOffsets;
         public readonly MethodCallDelegate Method;
 
         public RpcFieldInfo(MethodCallDelegate method)
         {
-            SyncableOffset = -1;
+            SyncableOffsets = Array.Empty<int>();
             Method = method;
         }
-        
-        public RpcFieldInfo(int syncableOffset, MethodCallDelegate method)
+
+        public RpcFieldInfo(int[] syncableOffsets, MethodCallDelegate method)
         {
-            SyncableOffset = syncableOffset;
+            SyncableOffsets = syncableOffsets;
             Method = method;
         }
     }
@@ -49,7 +84,7 @@ namespace LiteEntitySystem.Internal
             Id = ushort.MaxValue;
         }
     }
-    
+
     internal struct EntityClassData
     {
         public readonly ushort ClassId;
@@ -74,33 +109,33 @@ namespace LiteEntitySystem.Internal
 
         private readonly EntityFieldInfo[] _ownedRollbackFields;
         private readonly EntityFieldInfo[] _remoteRollbackFields;
-        
+
         private static readonly Type InternalEntityType = typeof(InternalEntity);
         internal static readonly Type SingletonEntityType = typeof(SingletonEntityLogic);
         private static readonly Type SyncableFieldType = typeof(SyncableField);
         private static readonly Type EntityLogicType = typeof(EntityLogic);
-        
+
         private readonly Queue<byte[]> _dataCache;
         private readonly int _dataCacheSize;
         private readonly int _maxHistoryCount;
         private readonly int _historyStart;
 
-        public Span<byte> ClientInterpolatedPrevData(InternalEntity e) => new (e.IOBuffer, 0, InterpolatedFieldsSize);
-        public Span<byte> ClientInterpolatedNextData(InternalEntity e) => new (e.IOBuffer, InterpolatedFieldsSize, InterpolatedFieldsSize);
-        public Span<byte> ClientPredictedData(InternalEntity e) => new (e.IOBuffer, InterpolatedFieldsSize*2, PredictedSize);
+        public Span<byte> ClientInterpolatedPrevData(InternalEntity e) => new(e.IOBuffer, 0, InterpolatedFieldsSize);
+        public Span<byte> ClientInterpolatedNextData(InternalEntity e) => new(e.IOBuffer, InterpolatedFieldsSize, InterpolatedFieldsSize);
+        public Span<byte> ClientPredictedData(InternalEntity e) => new(e.IOBuffer, InterpolatedFieldsSize * 2, PredictedSize);
 
         public EntityFieldInfo[] GetRollbackFields(bool isOwned) =>
             isOwned ? _ownedRollbackFields : _remoteRollbackFields;
-        
+
         public unsafe void WriteHistory(EntityLogic e, ushort tick)
         {
-            int historyOffset = ((tick % _maxHistoryCount)+1)*LagCompensatedSize;
+            int historyOffset = ((tick % _maxHistoryCount) + 1) * LagCompensatedSize;
             fixed (byte* history = &e.IOBuffer[_historyStart])
             {
                 for (int i = 0; i < LagCompensatedCount; i++)
                 {
                     ref var field = ref LagCompensatedFields[i];
-                    field.TypeProcessor.WriteTo(e, field.Offset, history + historyOffset);
+                    field.TypeProcessor.WriteTo(e, field.Offsets, history + historyOffset);
                     historyOffset += field.IntSize;
                 }
             }
@@ -108,8 +143,8 @@ namespace LiteEntitySystem.Internal
 
         public unsafe void LoadHistroy(NetPlayer player, EntityLogic e)
         {
-            int historyAOffset = ((player.StateATick % _maxHistoryCount)+1)*LagCompensatedSize;
-            int historyBOffset = ((player.StateBTick % _maxHistoryCount)+1)*LagCompensatedSize;
+            int historyAOffset = ((player.StateATick % _maxHistoryCount) + 1) * LagCompensatedSize;
+            int historyBOffset = ((player.StateBTick % _maxHistoryCount) + 1) * LagCompensatedSize;
             int historyCurrent = 0;
             fixed (byte* history = &e.IOBuffer[_historyStart])
             {
@@ -117,8 +152,8 @@ namespace LiteEntitySystem.Internal
                 {
                     ref var field = ref LagCompensatedFields[i];
                     field.TypeProcessor.LoadHistory(
-                        e, 
-                        field.Offset,
+                        e,
+                        field.Offsets,
                         history + historyCurrent,
                         history + historyAOffset,
                         history + historyBOffset,
@@ -138,12 +173,12 @@ namespace LiteEntitySystem.Internal
                 for (int i = 0; i < LagCompensatedCount; i++)
                 {
                     ref var field = ref LagCompensatedFields[i];
-                    field.TypeProcessor.SetFrom(e, field.Offset, history + historyOffset);
+                    field.TypeProcessor.SetFrom(e, field.Offsets, history + historyOffset);
                     historyOffset += field.IntSize;
                 }
             }
         }
-        
+
         public byte[] AllocateDataCache()
         {
             if (_dataCache.Count > 0)
@@ -165,6 +200,16 @@ namespace LiteEntitySystem.Internal
             }
         }
 
+        // PendingField carries both the FieldInfo and its metadata
+        private struct PendingField
+        {
+            public FieldInfo Field;
+            public string NamePrefix;
+            public List<int> Offsets;
+            public SyncVarFlags Flags;
+            public Type DeclaringType;
+        }
+
         public EntityClassData(EntityManager entityManager, ushort filterId, Type entType, RegisteredTypeInfo typeInfo)
         {
             _dataCache = new Queue<byte[]>();
@@ -184,110 +229,150 @@ namespace LiteEntitySystem.Internal
             BaseTypes = new BaseTypeInfo[tempBaseTypes.Count];
             for (int i = 0; i < BaseTypes.Length; i++)
                 BaseTypes[i] = new BaseTypeInfo(tempBaseTypes.Pop());
-            
+
             var fields = new List<EntityFieldInfo>();
             var syncableFields = new List<SyncableFieldInfo>();
             var lagCompensatedFields = new List<EntityFieldInfo>();
             var ownedRollbackFields = new List<EntityFieldInfo>();
             var remoteRollbackFields = new List<EntityFieldInfo>();
-            
+
+            Logger.LogError($"Class Data for : {entType}");
+
             var allTypesStack = Utils.GetBaseTypes(entType, InternalEntityType, true, true);
-            while(allTypesStack.Count > 0)
+            while (allTypesStack.Count > 0)
             {
                 var baseType = allTypesStack.Pop();
-                
+
                 var setFlagsAttribute = baseType.GetCustomAttribute<EntityFlagsAttribute>();
                 Flags |= setFlagsAttribute != null ? setFlagsAttribute.Flags : 0;
-                
-                //cache fields
-                foreach (var field in Utils.GetProcessedFields(baseType))
+
+                // Seed the PendingField stack with top-level fields
+                var fieldsStack = new Stack<PendingField>();
+                foreach (var f in Utils.GetProcessedFields(baseType))
                 {
-                    var ft = field.FieldType;
-                    if(Utils.IsRemoteCallType(ft) && !field.IsStatic)
-                        throw new Exception($"RemoteCalls should be static! (Class: {entType} Field: {field.Name})");
-                    
-                    if(field.IsStatic)
+                    var flags = f.GetCustomAttribute<SyncVarFlags>()
+                                ?? baseType.GetCustomAttribute<SyncVarFlags>()
+                                ?? new SyncVarFlags(SyncFlags.None);
+
+                    if (Utils.IsRemoteCallType(f.FieldType) && !f.IsStatic)
+                        throw new Exception($"RemoteCalls should be static! (Class: {entType} Field: {f.Name})");
+                    if (f.IsStatic)
                         continue;
-                    
-                    var syncVarFlags = field.GetCustomAttribute<SyncVarFlags>() ?? baseType.GetCustomAttribute<SyncVarFlags>();
-                    var syncFlags = syncVarFlags?.Flags ?? SyncFlags.None;
-                    int offset = Utils.GetFieldOffset(field);
-                    
-                    //syncvars
+
+                    var offset = Utils.GetFieldOffset(f);
+
+                    fieldsStack.Push(new PendingField
+                    {
+                        Field = f,
+                        NamePrefix = $"{baseType.Name}-{f.Name}",
+                        Offsets = new List<int> { offset },
+                        Flags = flags,
+                        DeclaringType = baseType
+                    });
+                }
+
+                // Process each pending field (handles nested SyncableFields inline)
+                while (fieldsStack.Count > 0)
+                {
+                    var ctx = fieldsStack.Pop();
+                    var field = ctx.Field;
+                    var ft = field.FieldType;
+                    var name = ctx.NamePrefix;
+                    var offsetMap = ctx.Offsets; // chain of offsets to this field
+                    var syncVarFlags = ctx.Flags;
+                    var syncFlags = syncVarFlags.Flags;
+
+                    if (Utils.IsRemoteCallType(ft) && !field.IsStatic)
+                        throw new Exception($"RemoteCalls should be static! (Class: {entType} Field: {field.Name})");
+                    if (field.IsStatic)
+                        continue;
+
+                    // --- SyncVar<T> handling ---
                     if (ft.IsGenericType && !ft.IsArray && ft.GetGenericTypeDefinition() == typeof(SyncVar<>))
                     {
-                        ft = ft.GetGenericArguments()[0];
-                        if (ft.IsEnum)
-                            ft = ft.GetEnumUnderlyingType();
+                        var innerType = ft.GetGenericArguments()[0];
+                        if (innerType.IsEnum)
+                            innerType = innerType.GetEnumUnderlyingType();
 
-                        if (!ValueTypeProcessor.Registered.TryGetValue(ft, out var valueTypeProcessor))
+                        if (!ValueTypeProcessor.Registered.TryGetValue(innerType, out var processor))
                         {
-                            Logger.LogError($"Unregistered field type: {ft}");
+                            Logger.LogError($"Unregistered field type: {innerType}");
                             continue;
                         }
-                        int fieldSize = valueTypeProcessor.Size;
-                        if (syncFlags.HasFlagFast(SyncFlags.Interpolated) && !ft.IsEnum)
+
+                        var fieldSize = processor.Size;
+
+                        // choose the correct constructor:
+                        EntityFieldInfo ef;
+                        if (ctx.DeclaringType.IsSubclassOf(SyncableFieldType))
                         {
-                            InterpolatedFieldsSize += fieldSize;
-                            InterpolatedCount++;
+                            // nested SyncableField's SyncVar<…>
+                            ef = new EntityFieldInfo(name, processor, offsetMap.ToArray(), syncVarFlags, FieldType.SyncableSyncVar);
+                            Logger.Log($"Registered syncable sync var field: {name} with offset {string.Join(",", offsetMap)}");
                         }
-                        var fieldInfo = new EntityFieldInfo($"{baseType.Name}-{field.Name}", valueTypeProcessor, offset, syncVarFlags);
-                        if (syncFlags.HasFlagFast(SyncFlags.LagCompensated))
+                        else
                         {
-                            lagCompensatedFields.Add(fieldInfo);
-                            LagCompensatedSize += fieldSize;
+                            // top-level field on the entity itself
+                            ef = new EntityFieldInfo(name, processor, offsetMap.ToArray(), syncVarFlags, FieldType.SyncVar);
+                            Logger.Log($"Registered field: {name} with offsets {string.Join(",", offsetMap)}");
+
+                            if (syncFlags.HasFlagFast(SyncFlags.Interpolated) && !ft.IsEnum)
+                            {
+                                InterpolatedFieldsSize += fieldSize;
+                                InterpolatedCount++;
+                            }
+
+                            if (syncFlags.HasFlagFast(SyncFlags.LagCompensated))
+                            {
+                                lagCompensatedFields.Add(ef);
+                                LagCompensatedSize += fieldSize;
+                            }
                         }
 
-                        if (fieldInfo.IsPredicted)
-                            PredictedSize += fieldSize;
+                        if (ef.IsPredicted)
+                            PredictedSize += ef.IntSize;
 
-                        fields.Add(fieldInfo);
-                        FixedFieldsSize += fieldSize;
+                        fields.Add(ef);
+                        FixedFieldsSize += ef.IntSize;
                     }
+                    // --- nested SyncableFieldType ---
                     else if (ft.IsSubclassOf(SyncableFieldType))
                     {
                         if (!field.IsInitOnly)
                             throw new Exception($"Syncable fields should be readonly! (Class: {entType} Field: {field.Name})");
-                        
-                        syncableFields.Add(new SyncableFieldInfo(offset, syncFlags));
-                        var syncableFieldTypesWithBase = Utils.GetBaseTypes(ft, SyncableFieldType, true, true);
-                        while(syncableFieldTypesWithBase.Count > 0)
+
+                        syncableFields.Add(new SyncableFieldInfo(name, offsetMap.ToArray(), syncVarFlags.Flags));
+                        Logger.Log($"Registered syncable field {name} with offsets {string.Join(",", offsetMap)}");
+
+                        var nestedTypes = Utils.GetBaseTypes(ft, SyncableFieldType, true, true);
+                        foreach (var nest in nestedTypes)
                         {
-                            var syncableType = syncableFieldTypesWithBase.Pop();
-                            //syncable fields
-                            foreach (var syncableField in Utils.GetProcessedFields(syncableType))
+                            foreach (var nestedField in Utils.GetProcessedFields(nest))
                             {
-                                var syncableFieldType = syncableField.FieldType;
-                                if(Utils.IsRemoteCallType(syncableFieldType) && !syncableField.IsStatic)
-                                    throw new Exception($"RemoteCalls should be static! (Class: {syncableType} Field: {syncableField.Name})");
-                                
-                                if (!syncableFieldType.IsValueType || 
-                                    !syncableFieldType.IsGenericType || 
-                                    syncableFieldType.GetGenericTypeDefinition() != typeof(SyncVar<>) ||
-                                    syncableField.IsStatic) 
-                                    continue;
+                                var nestedFlags = nestedField.GetCustomAttribute<SyncVarFlags>()
+                                                 ?? nest.GetCustomAttribute<SyncVarFlags>()
+                                                 ?? syncVarFlags;
 
-                                syncableFieldType = syncableFieldType.GetGenericArguments()[0];
-                                if (syncableFieldType.IsEnum)
-                                    syncableFieldType = syncableFieldType.GetEnumUnderlyingType();
+                                var nestFieldOffset = Utils.GetFieldOffset(nestedField);
 
-                                if (!ValueTypeProcessor.Registered.TryGetValue(syncableFieldType, out var valueTypeProcessor))
+                                // build new chain: existing chain + nestFieldOffset
+                                var nestedOffsetMap = new List<int>(offsetMap) { nestFieldOffset };
+
+                                fieldsStack.Push(new PendingField
                                 {
-                                    Logger.LogError($"Unregistered field type: {syncableFieldType}");
-                                    continue;
-                                }
-                                int syncvarOffset = Utils.GetFieldOffset(syncableField);
-                                var fieldInfo = new EntityFieldInfo($"{baseType.Name}-{field.Name}:{syncableField.Name}", valueTypeProcessor, offset, syncvarOffset, syncVarFlags);
-                                fields.Add(fieldInfo);
-                                FixedFieldsSize += fieldInfo.IntSize;
-                                if (fieldInfo.IsPredicted)
-                                    PredictedSize += fieldInfo.IntSize;
+                                    Field = nestedField,
+                                    NamePrefix = $"{name}:{nestedField.Name}",
+                                    Offsets = nestedOffsetMap,
+                                    Flags = nestedFlags,
+                                    DeclaringType = nest
+                                });
                             }
                         }
+                        continue;
                     }
                 }
             }
-            
+
             //sort by placing interpolated first
             fields.Sort((a, b) =>
             {
@@ -298,7 +383,7 @@ namespace LiteEntitySystem.Internal
             Fields = fields.ToArray();
             SyncableFields = syncableFields.ToArray();
             FieldsCount = Fields.Length;
-            FieldsFlagsSize = (FieldsCount-1) / 8 + 1;
+            FieldsFlagsSize = (FieldsCount - 1) / 8 + 1;
             LagCompensatedFields = lagCompensatedFields.ToArray();
             LagCompensatedCount = LagCompensatedFields.Length;
 
@@ -314,7 +399,7 @@ namespace LiteEntitySystem.Internal
                     field.PredictedOffset = predictedOffset;
                     predictedOffset += field.IntSize;
                     ownedRollbackFields.Add(field);
-                    if(field.Flags.HasFlagFast(SyncFlags.AlwaysRollback))
+                    if (field.Flags.HasFlagFast(SyncFlags.AlwaysRollback))
                         remoteRollbackFields.Add(field);
                 }
                 else
@@ -322,11 +407,11 @@ namespace LiteEntitySystem.Internal
                     field.PredictedOffset = -1;
                 }
             }
-            
+
             //cache rollbackFields
             _ownedRollbackFields = ownedRollbackFields.ToArray();
             _remoteRollbackFields = remoteRollbackFields.ToArray();
-            
+
             _maxHistoryCount = (byte)entityManager.MaxHistorySize;
             int historySize = entType.IsSubclassOf(EntityLogicType) ? (_maxHistoryCount + 1) * LagCompensatedSize : 0;
             if (entityManager.IsServer)

--- a/LiteEntitySystem/Internal/EntityFieldInfo.cs
+++ b/LiteEntitySystem/Internal/EntityFieldInfo.cs
@@ -1,4 +1,6 @@
-﻿namespace LiteEntitySystem.Internal
+﻿using System.Linq;
+
+namespace LiteEntitySystem.Internal
 {
     internal enum FieldType
     {
@@ -10,8 +12,7 @@
     {
         public readonly string Name; //used for debug
         public readonly ValueTypeProcessor TypeProcessor;
-        public readonly int Offset;
-        public readonly int SyncableSyncVarOffset;
+        public readonly int[] Offsets;
         public readonly uint Size;
         public readonly int IntSize;
         public readonly FieldType FieldType;
@@ -26,16 +27,16 @@
         public EntityFieldInfo(
             string name,
             ValueTypeProcessor valueTypeProcessor,
-            int offset,
-            SyncVarFlags flags)
+            int[] offsets,
+            SyncVarFlags flags,
+            FieldType fieldType)
         {
             Name = name;
             TypeProcessor = valueTypeProcessor;
-            SyncableSyncVarOffset = -1;
-            Offset = offset;
+            Offsets = offsets;
             Size = (uint)TypeProcessor.Size;
             IntSize = TypeProcessor.Size;
-            FieldType = FieldType.SyncVar;
+            FieldType = fieldType;
             FixedOffset = 0;
             PredictedOffset = 0;
             OnSync = null;
@@ -46,27 +47,27 @@
         }
 
         //For syncable syncvar
-        public EntityFieldInfo(
-            string name,
-            ValueTypeProcessor valueTypeProcessor,
-            int offset,
-            int syncableSyncVarOffset,
-            SyncVarFlags flags)
-        {
-            Name = name;
-            TypeProcessor = valueTypeProcessor;
-            SyncableSyncVarOffset = syncableSyncVarOffset;
-            Offset = offset;
-            Size = (uint)TypeProcessor.Size;
-            IntSize = TypeProcessor.Size;
-            FieldType = FieldType.SyncableSyncVar;
-            FixedOffset = 0;
-            PredictedOffset = 0;
-            OnSync = null;
-            Flags = flags?.Flags ?? SyncFlags.None;
-            IsPredicted = Flags.HasFlagFast(SyncFlags.AlwaysRollback) ||
-                          (!Flags.HasFlagFast(SyncFlags.OnlyForOtherPlayers) &&
-                           !Flags.HasFlagFast(SyncFlags.NeverRollBack));
-        }
+        // public EntityFieldInfo(
+        //     string name,
+        //     ValueTypeProcessor valueTypeProcessor,
+        //     int offset,
+        //     int syncableSyncVarOffset,
+        //     SyncVarFlags flags)
+        // {
+        //     Name = name;
+        //     TypeProcessor = valueTypeProcessor;
+        //     SyncableSyncVarOffset = syncableSyncVarOffset;
+        //     Offset = offset;
+        //     Size = (uint)TypeProcessor.Size;
+        //     IntSize = TypeProcessor.Size;
+        //     FieldType = FieldType.SyncableSyncVar;
+        //     FixedOffset = 0;
+        //     PredictedOffset = 0;
+        //     OnSync = null;
+        //     Flags = flags?.Flags ?? SyncFlags.None;
+        //     IsPredicted = Flags.HasFlagFast(SyncFlags.AlwaysRollback) ||
+        //                   (!Flags.HasFlagFast(SyncFlags.OnlyForOtherPlayers) &&
+        //                    !Flags.HasFlagFast(SyncFlags.NeverRollBack));
+        // }
     }
 }

--- a/LiteEntitySystem/Internal/StateSerializer.cs
+++ b/LiteEntitySystem/Internal/StateSerializer.cs
@@ -158,8 +158,16 @@ namespace LiteEntitySystem.Internal
                 _entity.OnSyncRequested();
                 var syncableFields = _entity.ClassData.SyncableFields;
                 for (int i = 0; i < syncableFields.Length; i++)
-                    RefMagic.RefFieldValue<SyncableField>(_entity, syncableFields[i].Offset)
-                        .OnSyncRequested();
+                {
+                    InternalBaseClass syncable = _entity;
+                    for (int j = 0; j < syncableFields[i].Offsets.Length; j++)
+                    {
+                        syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, syncableFields[i].Offsets[j]);
+                        if (syncable == null)
+                            throw new NullReferenceException($"SyncVar at offset {syncableFields[i].Offsets[j]} is null");
+                    }
+                    ((SyncableField)syncable).OnSyncRequested();
+                }
             }
             catch (Exception e)
             {

--- a/LiteEntitySystem/Internal/ValueTypeProcessor.cs
+++ b/LiteEntitySystem/Internal/ValueTypeProcessor.cs
@@ -14,56 +14,134 @@ namespace LiteEntitySystem.Internal
         protected ValueTypeProcessor(int size) => Size = size;
 
         internal abstract void InitSyncVar(InternalBaseClass obj, int offset, InternalEntity entity, ushort fieldId);
-        internal abstract void SetFrom(InternalBaseClass obj, int offset, byte* data);
-        internal abstract bool SetFromAndSync(InternalBaseClass obj, int offset, byte* data);
-        internal abstract void WriteTo(InternalBaseClass obj, int offset, byte* data);
-        internal abstract void SetInterpolation(InternalBaseClass obj, int offset, byte* prev, byte* current, float fTimer);
-        internal abstract void LoadHistory(InternalBaseClass obj, int offset, byte* tempHistory, byte* historyA, byte* historyB, float lerpTime);
-        internal abstract int GetHashCode(InternalBaseClass obj, int offset);
-        internal abstract string ToString(InternalBaseClass obj, int offset);
+        internal abstract void SetFrom(InternalBaseClass obj, int[] offsetMap, byte* data);
+        internal abstract bool SetFromAndSync(InternalBaseClass obj, int[] offsetMap, byte* data);
+        internal abstract void WriteTo(InternalBaseClass obj, int[] offsetMap, byte* data);
+        internal abstract void SetInterpolation(InternalBaseClass obj, int[] offsetMap, byte* prev, byte* current, float fTimer);
+        internal abstract void LoadHistory(InternalBaseClass obj, int[] offsetMap, byte* tempHistory, byte* historyA, byte* historyB, float lerpTime);
+        internal abstract int GetHashCode(InternalBaseClass obj, int[] offsetMap);
+        internal abstract string ToString(InternalBaseClass obj, int[] offsetMap);
     }
 
     internal unsafe class ValueTypeProcessor<T> : ValueTypeProcessor where T : unmanaged
     {
         public ValueTypeProcessor() : base(sizeof(T)) { }
 
-        internal override void SetInterpolation(InternalBaseClass obj, int offset, byte* prev, byte* current, float fTimer) =>
+        internal override void SetInterpolation(InternalBaseClass obj, int[] offsetMap, byte* prev, byte* current, float fTimer) =>
             throw new Exception($"This type: {typeof(T)} can't be interpolated");
 
-        internal override void InitSyncVar(InternalBaseClass obj, int offset, InternalEntity entity, ushort fieldId) =>
-            RefMagic.RefFieldValue<SyncVar<T>>(obj, offset).Init(entity, fieldId);
-
-        internal override void LoadHistory(InternalBaseClass obj, int offset, byte* tempHistory, byte* historyA, byte* historyB, float lerpTime)
+        internal override void InitSyncVar(InternalBaseClass obj, int offset, InternalEntity entity, ushort fieldId)
         {
-            ref var a = ref RefMagic.RefFieldValue<SyncVar<T>>(obj, offset);
+            
+            RefMagic.RefFieldValue<SyncVar<T>>(obj, offset).Init(entity, fieldId);
+        }
+
+        internal override void LoadHistory(InternalBaseClass obj, int[] offsetMap, byte* tempHistory, byte* historyA, byte* historyB, float lerpTime)
+        {
+            InternalBaseClass syncable = obj;
+            for (int i = 0; i < offsetMap.Length-1; i++)
+            {
+                syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, offsetMap[i]);
+                if (syncable == null)
+                    throw new NullReferenceException($"SyncVar at offset {offsetMap[i]} is null");
+            }
+            ref var a = ref RefMagic.RefFieldValue<SyncVar<T>>(syncable, offsetMap[offsetMap.Length-1]);
             *(T*)tempHistory = a;
             a.SetDirect(*(T*)historyA);
         }
         
-        internal override void SetFrom(InternalBaseClass obj, int offset, byte* data) =>
-            RefMagic.RefFieldValue<SyncVar<T>>(obj, offset).SetDirect(*(T*)data);
+        internal override void SetFrom(InternalBaseClass obj, int[] offsetMap, byte* data)
+        {
+            InternalBaseClass syncable = obj;
+            for (int i = 0; i < offsetMap.Length-1; i++)
+            {
+                syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, offsetMap[i]);
+                if (syncable == null)
+                    throw new NullReferenceException($"SyncVar at offset {offsetMap[i]} is null");
+            }
+            RefMagic.RefFieldValue<SyncVar<T>>(syncable, offsetMap[offsetMap.Length-1]).SetDirect(*(T*)data);
+        }
 
-        internal override bool SetFromAndSync(InternalBaseClass obj, int offset, byte* data) =>
-            RefMagic.RefFieldValue<SyncVar<T>>(obj, offset).SetFromAndSync(data);
+        internal override bool SetFromAndSync(InternalBaseClass obj, int[] offsetMap, byte* data)
+        {
+            InternalBaseClass syncable = obj;
+            for (int i = 0; i < offsetMap.Length-1; i++)
+            {
+                syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, offsetMap[i]);
+                if (syncable == null)
+                    throw new NullReferenceException($"SyncVar at offset {offsetMap[i]} is null");
+            }
+            return RefMagic.RefFieldValue<SyncVar<T>>(syncable, offsetMap[offsetMap.Length-1]).SetFromAndSync(data);
+        }
+            
 
-        internal override void WriteTo(InternalBaseClass obj, int offset, byte* data) =>
-            *(T*)data = RefMagic.RefFieldValue<SyncVar<T>>(obj, offset);
+        internal override void WriteTo(InternalBaseClass obj, int[] offsetMap, byte* data)
+        {
+            InternalBaseClass syncable = obj;
+            for (int i = 0; i < offsetMap.Length-1; i++)
+            {
+                syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, offsetMap[i]);
+                if (syncable == null)
+                    throw new NullReferenceException($"SyncVar at offset {offsetMap[i]} is null");
+            }
+            
+            *(T*)data = RefMagic.RefFieldValue<SyncVar<T>>(syncable, offsetMap[offsetMap.Length-1]);
+        }
 
-        internal override int GetHashCode(InternalBaseClass obj, int offset) =>
-            RefMagic.RefFieldValue<SyncVar<T>>(obj, offset).GetHashCode();
+        internal override int GetHashCode(InternalBaseClass obj, int[] offsetMap)
+        {
+            InternalBaseClass syncable = obj;
+            for (int i = 0; i < offsetMap.Length-1; i++)
+            {
+                syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, offsetMap[i]);
+                if (syncable == null)
+                    throw new NullReferenceException($"SyncVar at offset {offsetMap[i]} is null");
+            }
+            
+            return RefMagic.RefFieldValue<SyncVar<T>>(syncable, offsetMap[offsetMap.Length-1]).GetHashCode();
+        }
+            
         
-        internal override string ToString(InternalBaseClass obj, int offset) =>
-            RefMagic.RefFieldValue<SyncVar<T>>(obj, offset).ToString();
+        internal override string ToString(InternalBaseClass obj, int[] offsetMap)
+        {
+            InternalBaseClass syncable = obj;
+            for (int i = 0; i < offsetMap.Length-1; i++)
+            {
+                syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, offsetMap[i]);
+                if (syncable == null)
+                    throw new NullReferenceException($"SyncVar at offset {offsetMap[i]} is null");
+            }
+            
+            return RefMagic.RefFieldValue<SyncVar<T>>(syncable, offsetMap[offsetMap.Length-1]).ToString();
+        }
     }
 
     internal class ValueTypeProcessorInt : ValueTypeProcessor<int>
     {
-        internal override unsafe void SetInterpolation(InternalBaseClass obj, int offset, byte* prev, byte* current, float fTimer) =>
-            RefMagic.RefFieldValue<SyncVar<int>>(obj, offset).SetDirect(Utils.Lerp(*(int*)prev, *(int*)current, fTimer));
-        
-        internal override unsafe void LoadHistory(InternalBaseClass obj, int offset, byte* tempHistory, byte* historyA, byte* historyB, float lerpTime)
+        internal override unsafe void SetInterpolation(InternalBaseClass obj, int[] offsetMap, byte* prev, byte* current, float fTimer)
         {
-            ref var a = ref RefMagic.RefFieldValue<SyncVar<int>>(obj, offset);
+            InternalBaseClass syncable = obj;
+            for (int i = 0; i < offsetMap.Length-1; i++)
+            {
+                syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, offsetMap[i]);
+                if (syncable == null)
+                    throw new NullReferenceException($"SyncVar at offset {offsetMap[i]} is null");
+            }
+            
+            RefMagic.RefFieldValue<SyncVar<int>>(syncable, offsetMap[offsetMap.Length-1]).SetDirect(Utils.Lerp(*(int*)prev, *(int*)current, fTimer));
+        }
+        
+        internal override unsafe void LoadHistory(InternalBaseClass obj, int[] offsetMap, byte* tempHistory, byte* historyA, byte* historyB, float lerpTime)
+        {
+            InternalBaseClass syncable = obj;
+            for (int i = 0; i < offsetMap.Length-1; i++)
+            {
+                syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, offsetMap[i]);
+                if (syncable == null)
+                    throw new NullReferenceException($"SyncVar at offset {offsetMap[i]} is null");
+            }
+
+            ref var a = ref RefMagic.RefFieldValue<SyncVar<int>>(syncable, offsetMap[offsetMap.Length-1]);
             *(int*)tempHistory = a;
             a.SetDirect(Utils.Lerp(*(int*)historyA, *(int*)historyB, lerpTime));
         }
@@ -71,12 +149,30 @@ namespace LiteEntitySystem.Internal
     
     internal class ValueTypeProcessorLong : ValueTypeProcessor<long>
     {
-        internal override unsafe void SetInterpolation(InternalBaseClass obj, int offset, byte* prev, byte* current, float fTimer) =>
-            RefMagic.RefFieldValue<SyncVar<long>>(obj, offset).SetDirect(Utils.Lerp(*(long*)prev, *(long*)current, fTimer));
-        
-        internal override unsafe void LoadHistory(InternalBaseClass obj, int offset, byte* tempHistory, byte* historyA, byte* historyB, float lerpTime)
+        internal override unsafe void SetInterpolation(InternalBaseClass obj, int[] offsetMap, byte* prev, byte* current, float fTimer)
         {
-            ref var a = ref RefMagic.RefFieldValue<SyncVar<long>>(obj, offset);
+            InternalBaseClass syncable = obj;
+            for (int i = 0; i < offsetMap.Length-1; i++)
+            {
+                syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, offsetMap[i]);
+                if (syncable == null)
+                    throw new NullReferenceException($"SyncVar at offset {offsetMap[i]} is null");
+            }
+
+            RefMagic.RefFieldValue<SyncVar<long>>(syncable, offsetMap[offsetMap.Length-1]).SetDirect(Utils.Lerp(*(long*)prev, *(long*)current, fTimer));
+        }
+        
+        internal override unsafe void LoadHistory(InternalBaseClass obj, int[] offsetMap, byte* tempHistory, byte* historyA, byte* historyB, float lerpTime)
+        {
+            InternalBaseClass syncable = obj;
+            for (int i = 0; i < offsetMap.Length-1; i++)
+            {
+                syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, offsetMap[i]);
+                if (syncable == null)
+                    throw new NullReferenceException($"SyncVar at offset {offsetMap[i]} is null");
+            }
+
+           ref var a = ref RefMagic.RefFieldValue<SyncVar<long>>(syncable, offsetMap[offsetMap.Length-1]);
             *(long*)tempHistory = a;
             a.SetDirect(Utils.Lerp(*(long*)historyA, *(long*)historyB, lerpTime));
         }
@@ -84,12 +180,30 @@ namespace LiteEntitySystem.Internal
 
     internal class ValueTypeProcessorFloat : ValueTypeProcessor<float>
     {
-        internal override unsafe void SetInterpolation(InternalBaseClass obj, int offset, byte* prev, byte* current, float fTimer) =>
-            RefMagic.RefFieldValue<SyncVar<float>>(obj, offset).SetDirect(Utils.Lerp(*(float*)prev, *(float*)current, fTimer));
-        
-        internal override unsafe void LoadHistory(InternalBaseClass obj, int offset, byte* tempHistory, byte* historyA, byte* historyB, float lerpTime)
+        internal override unsafe void SetInterpolation(InternalBaseClass obj, int[] offsetMap, byte* prev, byte* current, float fTimer)
         {
-            ref var a = ref RefMagic.RefFieldValue<SyncVar<float>>(obj, offset);
+            InternalBaseClass syncable = obj;
+            for (int i = 0; i < offsetMap.Length-1; i++)
+            {
+                syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, offsetMap[i]);
+                if (syncable == null)
+                    throw new NullReferenceException($"SyncVar at offset {offsetMap[i]} is null");
+            }
+
+            RefMagic.RefFieldValue<SyncVar<float>>(syncable, offsetMap[offsetMap.Length-1]).SetDirect(Utils.Lerp(*(float*)prev, *(float*)current, fTimer));
+        }
+        
+        internal override unsafe void LoadHistory(InternalBaseClass obj, int[] offsetMap, byte* tempHistory, byte* historyA, byte* historyB, float lerpTime)
+        {
+            InternalBaseClass syncable = obj;
+            for (int i = 0; i < offsetMap.Length-1; i++)
+            {
+                syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, offsetMap[i]);
+                if (syncable == null)
+                    throw new NullReferenceException($"SyncVar at offset {offsetMap[i]} is null");
+            }
+            
+            ref var a = ref RefMagic.RefFieldValue<SyncVar<float>>(syncable, offsetMap[offsetMap.Length-1]);
             *(float*)tempHistory = a;
             a.SetDirect(Utils.Lerp(*(float*)historyA, *(float*)historyB, lerpTime));
         }
@@ -97,12 +211,30 @@ namespace LiteEntitySystem.Internal
     
     internal class ValueTypeProcessorDouble : ValueTypeProcessor<double>
     {
-        internal override unsafe void SetInterpolation(InternalBaseClass obj, int offset, byte* prev, byte* current, float fTimer) =>
-            RefMagic.RefFieldValue<SyncVar<double>>(obj, offset).SetDirect(Utils.Lerp(*(double*)prev, *(double*)current, fTimer));
-        
-        internal override unsafe void LoadHistory(InternalBaseClass obj, int offset, byte* tempHistory, byte* historyA, byte* historyB, float lerpTime)
+        internal override unsafe void SetInterpolation(InternalBaseClass obj, int[] offsetMap, byte* prev, byte* current, float fTimer)
         {
-            ref var a = ref RefMagic.RefFieldValue<SyncVar<double>>(obj, offset);
+            InternalBaseClass syncable = obj;
+            for (int i = 0; i < offsetMap.Length-1; i++)
+            {
+                syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, offsetMap[i]);
+                if (syncable == null)
+                    throw new NullReferenceException($"SyncVar at offset {offsetMap[i]} is null");
+            }
+            
+            RefMagic.RefFieldValue<SyncVar<double>>(syncable, offsetMap[offsetMap.Length-1]).SetDirect(Utils.Lerp(*(double*)prev, *(double*)current, fTimer));
+        }
+        
+        internal override unsafe void LoadHistory(InternalBaseClass obj, int[] offsetMap, byte* tempHistory, byte* historyA, byte* historyB, float lerpTime)
+        {
+            InternalBaseClass syncable = obj;
+            for (int i = 0; i < offsetMap.Length-1; i++)
+            {
+                syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, offsetMap[i]);
+                if (syncable == null)
+                    throw new NullReferenceException($"SyncVar at offset {offsetMap[i]} is null");
+            }
+
+            ref var a = ref RefMagic.RefFieldValue<SyncVar<double>>(syncable, offsetMap[offsetMap.Length-1]);
             *(double*)tempHistory = a;
             a.SetDirect(Utils.Lerp(*(double*)historyA, *(double*)historyB, lerpTime));
         }
@@ -112,12 +244,30 @@ namespace LiteEntitySystem.Internal
     {
         private readonly InterpolatorDelegateWithReturn<T> _interpDelegate;
 
-        internal override void SetInterpolation(InternalBaseClass obj, int offset, byte* prev, byte* current, float fTimer) =>
-            RefMagic.RefFieldValue<SyncVar<T>>(obj, offset).SetDirect(_interpDelegate?.Invoke(*(T*)prev, *(T*)current, fTimer) ?? *(T*)prev);
-        
-        internal override void LoadHistory(InternalBaseClass obj, int offset, byte* tempHistory, byte* historyA, byte* historyB, float lerpTime)
+        internal override void SetInterpolation(InternalBaseClass obj, int[] offsetMap, byte* prev, byte* current, float fTimer)
         {
-            ref var a = ref RefMagic.RefFieldValue<SyncVar<T>>(obj, offset);
+            InternalBaseClass syncable = obj;
+            for (int i = 0; i < offsetMap.Length-1; i++)
+            {
+                syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, offsetMap[i]);
+                if (syncable == null)
+                    throw new NullReferenceException($"SyncVar at offset {offsetMap[i]} is null");
+            }
+
+            RefMagic.RefFieldValue<SyncVar<T>>(syncable, offsetMap[offsetMap.Length-1]).SetDirect(_interpDelegate?.Invoke(*(T*)prev, *(T*)current, fTimer) ?? *(T*)prev);
+        }
+        
+        internal override void LoadHistory(InternalBaseClass obj, int[] offsetMap, byte* tempHistory, byte* historyA, byte* historyB, float lerpTime)
+        {
+            InternalBaseClass syncable = obj;
+            for (int i = 0; i < offsetMap.Length-1; i++)
+            {
+                syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, offsetMap[i]);
+                if (syncable == null)
+                    throw new NullReferenceException($"SyncVar at offset {offsetMap[i]} is null");
+            }
+            
+            ref var a = ref RefMagic.RefFieldValue<SyncVar<T>>(syncable, offsetMap[offsetMap.Length-1]);
             *(T*)tempHistory = a;
             a.SetDirect(_interpDelegate?.Invoke(*(T*)historyA, *(T*)historyB, lerpTime) ?? *(T*)historyA);
         }

--- a/LiteEntitySystem/RPCRegistrator.cs
+++ b/LiteEntitySystem/RPCRegistrator.cs
@@ -248,14 +248,14 @@ namespace LiteEntitySystem
     public readonly ref struct SyncableRPCRegistrator
     {
         private readonly List<RpcFieldInfo> _calls;
-        private readonly int _syncableOffset;
+        private readonly int[] _syncableOffsets;
         private readonly ushort _initialCallsSize;
 
-        internal SyncableRPCRegistrator(int syncableOffset, List<RpcFieldInfo> remoteCallsList)
+        internal SyncableRPCRegistrator(int[] syncableOffsets, List<RpcFieldInfo> remoteCallsList)
         {
             _calls = remoteCallsList;
             _initialCallsSize = (ushort)_calls.Count;
-            _syncableOffset = syncableOffset;
+            _syncableOffsets = syncableOffsets;
         }
         
         public void CreateClientAction<TSyncField>(TSyncField self, Action methodToCall, ref RemoteCall remoteCallHandle) where TSyncField : SyncableField
@@ -286,28 +286,28 @@ namespace LiteEntitySystem
         {
             if (!remoteCallHandle.Initialized)
                 remoteCallHandle = new RemoteCall(null, (ushort)(_calls.Count - _initialCallsSize), 0);
-            _calls.Add(new RpcFieldInfo(_syncableOffset, RemoteCall.CreateMCD(methodToCall)));
+            _calls.Add(new RpcFieldInfo(_syncableOffsets, RemoteCall.CreateMCD(methodToCall)));
         }
 
         public void CreateClientAction<TSyncField, T>(Action<TSyncField, T> methodToCall, ref RemoteCall<T> remoteCallHandle) where T : unmanaged where TSyncField : SyncableField
         {
             if (!remoteCallHandle.Initialized)
                 remoteCallHandle = new RemoteCall<T>(null, (ushort)(_calls.Count - _initialCallsSize), 0);
-            _calls.Add(new RpcFieldInfo(_syncableOffset, RemoteCall<T>.CreateMCD(methodToCall)));
+            _calls.Add(new RpcFieldInfo(_syncableOffsets, RemoteCall<T>.CreateMCD(methodToCall)));
         }
         
         public void CreateClientAction<TSyncField, T>(SpanAction<TSyncField, T> methodToCall, ref RemoteCallSpan<T> remoteCallHandle) where T : unmanaged where TSyncField : SyncableField
         {
             if (!remoteCallHandle.Initialized)
                 remoteCallHandle = new RemoteCallSpan<T>(null, (ushort)(_calls.Count - _initialCallsSize), 0);
-            _calls.Add(new RpcFieldInfo(_syncableOffset, RemoteCallSpan<T>.CreateMCD(methodToCall)));
+            _calls.Add(new RpcFieldInfo(_syncableOffsets, RemoteCallSpan<T>.CreateMCD(methodToCall)));
         }
         
         public void CreateClientAction<TSyncField, T>(Action<TSyncField, T> methodToCall, ref RemoteCallSerializable<T> remoteCallHandle) where T : struct, ISpanSerializable where TSyncField : SyncableField
         {
             if (!remoteCallHandle.Initialized)
                 remoteCallHandle = new RemoteCallSerializable<T>(null, (ushort)(_calls.Count - _initialCallsSize), 0);
-            _calls.Add(new RpcFieldInfo(_syncableOffset, RemoteCallSerializable<T>.CreateMCD(methodToCall)));
+            _calls.Add(new RpcFieldInfo(_syncableOffsets, RemoteCallSerializable<T>.CreateMCD(methodToCall)));
         }
     }
 }

--- a/LiteEntitySystem/Utils.cs
+++ b/LiteEntitySystem/Utils.cs
@@ -283,6 +283,33 @@ namespace LiteEntitySystem
                 : (Marshal.ReadInt32(fieldInfo.FieldHandle.Value + DotNetOffset) & 0xFFFFFF) + IntPtr.Size;
         }
 
+        internal static SyncableField GetSyncableField(InternalBaseClass baseClass, int[] offsets)
+        {
+            InternalBaseClass syncable = baseClass;
+            for (int j = 0; j < offsets.Length; j++)
+            {
+                syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, offsets[j]);
+                if (syncable == null)
+                    throw new NullReferenceException($"SyncableField at offset {offsets[j]} is null");
+            }
+
+            return (SyncableField)syncable;
+        }
+
+        internal static SyncVar<T> GetSyncableSyncVar<T>(InternalBaseClass baseClass, int[] offsets) where T : unmanaged
+        {
+            InternalBaseClass syncable = baseClass;
+            for (int i = 0; i < offsets.Length-1; i++)
+            {
+                syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, offsets[i]);
+                if (syncable == null)
+                    throw new NullReferenceException($"SyncableField at offset {offsets[i]} is null");
+            }
+            ref var a = ref RefMagic.RefFieldValue<SyncVar<T>>(syncable, offsets[offsets.Length-1]);
+
+            return a;
+        }
+
         static Utils()
         {            
             IsMono = Type.GetType("Mono.Runtime") != null


### PR DESCRIPTION
Added the ability for the EntityClassData constructor to find and register nested SyncableFields and their SyncVars

Since reference types are stored in the parent object as a pointer to a separately‐allocated object I've created a map that allows for chaining to the target offset.

NOTE: this is just a rough pass idea that is not final. while it does work I don't know much about optimizations. I more or less want to get your opinion as I know the multiple calls to traverse the object is a bit much I couldn't think of another way. Though as I mention it does seem to work, but was not thoroughly test.

``` C#
internal struct SyncableFieldInfo
{
    public readonly string Name;

    public readonly int[] Offsets;

    public readonly SyncFlags Flags;

    public ushort RPCOffset;

    public SyncableFieldInfo(string name, int[] offsets, SyncFlags flags)
    {
        Name = name;
        Offsets = offsets;
        Flags = flags;
        RPCOffset = ushort.MaxValue;
    }
}
```

``` C#

internal static SyncVar<T> GetSyncableSyncVar<T>(InternalBaseClass baseClass, int[] offsets) where T : unmanaged
{
    InternalBaseClass syncable = baseClass;
    for (int i = 0; i < offsets.Length-1; i++)
    {
        syncable = RefMagic.RefFieldValue<InternalBaseClass>(syncable, offsets[i]);
        if (syncable == null)
            throw new NullReferenceException($"SyncableField at offset {offsets[i]} is null");
    }
    ref var a = ref RefMagic.RefFieldValue<SyncVar<T>>(syncable, offsets[offsets.Length-1]);

    return a;
}
```