### PR TITLE
Fix RefMagic.dll NuGet package path for multi-target builds

### DIFF
--- a/LiteEntitySystem/LiteEntitySystem.csproj
+++ b/LiteEntitySystem/LiteEntitySystem.csproj
@@ -41,8 +41,15 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Content Include="..\LiteEntitySystemAnalyzer\bin\$(Configuration)\netstandard2.0\LiteEntitySystemAnalyzer.dll" Pack="true" PackagePath="analyzers\dotnet\cs\" />
-      <Content Include="ILPart\RefMagic.dll" Pack="true" PackagePath="lib\$(TargetFramework)" />
+      <None Include="..\LiteEntitySystemAnalyzer\bin\$(Configuration)\netstandard2.0\LiteEntitySystemAnalyzer.dll" Pack="true" PackagePath="analyzers\dotnet\cs\" />
       <None Include="..\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
+
+    <!-- RefMagic.dll must be included for each target framework -->
+    <Target Name="AddRefMagicToPackage" BeforeTargets="_GetPackageFiles">
+      <ItemGroup>
+        <None Include="ILPart\RefMagic.dll" Pack="true" PackagePath="lib/netstandard2.1" />
+        <None Include="ILPart\RefMagic.dll" Pack="true" PackagePath="lib/net8.0" />
+      </ItemGroup>
+    </Target>
 </Project>


### PR DESCRIPTION
## Summary
- Fixed RefMagic.dll being placed in `lib/` instead of `lib/netstandard2.1/` and `lib/net8.0/`
- The `$(TargetFramework)` variable in `PackagePath` doesn't expand correctly during multi-target pack
- Use a Target with `BeforeTargets="_GetPackageFiles"` to explicitly include RefMagic.dll in each framework-specific folder

## Problem
When consumers restore LiteEntitySystem 1.2.1, RefMagic.dll ends up in `~/.nuget/packages/liteentitysystem/1.2.1/lib/` instead of the framework-specific folders. This causes a `FileNotFoundException` at runtime because the .NET runtime looks for dependencies in the framework-specific folder.

## Solution
Use an MSBuild target to add RefMagic.dll to the package with explicit paths for each target framework, which runs at the correct time during the pack process.

## Test plan
- [x] Build the project with `dotnet build -c Release`
- [x] Verify the generated `.nupkg` contains RefMagic.dll in both `lib/netstandard2.1/` and `lib/net8.0/`