### PR TITLE
Use Ordinal collation for SyncVar field layout ordering (fixes cross-peer FixedOffset mismatch)

### DIFF
--- a/LiteEntitySystem/Internal/EntityClassData.cs
+++ b/LiteEntitySystem/Internal/EntityClassData.cs
@@ -308,11 +308,16 @@ namespace LiteEntitySystem.Internal
             }
             
             //sort by placing interpolated first
+            // List.Sort is UNSTABLE, so a comparator that only ranks the interpolated flag leaves the order of
+            // equal-ranked fields implementation-defined — which can differ across .NET runtimes and break the
+            // cross-peer field layout. Tie-break by the (unique) field Name with Ordinal comparison to make the
+            // order a total, environment-independent ordering.
             fields.Sort((a, b) =>
             {
                 int wa = a.Flags.HasFlagFast(SyncFlags.Interpolated) ? 1 : 0;
                 int wb = b.Flags.HasFlagFast(SyncFlags.Interpolated) ? 1 : 0;
-                return wb - wa;
+                if (wa != wb) return wb - wa;
+                return string.CompareOrdinal(a.Name, b.Name);
             });
             Fields = fields.ToArray();
             SyncableFields = syncableFields.ToArray();

--- a/LiteEntitySystem/Utils.cs
+++ b/LiteEntitySystem/Utils.cs
@@ -222,7 +222,14 @@ namespace LiteEntitySystem
                                    BindingFlags.NonPublic |
                                    BindingFlags.DeclaredOnly |
                                    BindingFlags.Static);
-            Array.Sort(fArr, (f1, f2) => string.Compare(f1.Name, f2.Name, StringComparison.InvariantCulture));
+            // Sort field names with Ordinal (byte-value) comparison, NOT culture-sensitive InvariantCulture.
+            // The serialized field layout (FixedOffset assignment) is derived from this order and must be identical
+            // on every peer. InvariantCulture is ICU-dependent: a full-ICU peer and an invariant-globalization peer
+            // (e.g. a server published with InvariantGlobalization=true, or any runtime where ICU is absent) can order
+            // underscore-prefixed identifiers (_controller, _controlledEntity, _parentId, ...) differently, producing
+            // mismatched FixedOffsets so a peer reads non-interpolated SyncVars from the wrong wire offset. Ordinal is
+            // environment-independent and is the correct collation for code identifiers.
+            Array.Sort(fArr, (f1, f2) => string.CompareOrdinal(f1.Name, f2.Name));
             return fArr;
         }
 


### PR DESCRIPTION
Fixes #40.

## Problem

The serialized field layout — each SyncVar's `FixedOffset` on the wire — is derived from a sort of field names, so that order **must be identical on every peer**. Two sort sites used environment-dependent comparisons:

1. **`Utils.GetProcessedFields`** sorted with `StringComparison.InvariantCulture`, which is ICU-dependent. A full-ICU peer and an invariant-globalization peer (e.g. a dedicated server published with `<InvariantGlobalization>true</InvariantGlobalization>`, or any runtime where ICU is absent) order underscore-prefixed identifiers like `_controller`, `_controlledEntity`, `_parentId` **differently**, assigning mismatched `FixedOffset`s. A peer then reads non-interpolated SyncVars from the **wrong wire offset** — silent state corruption, no exception. In our project this surfaced as a client reading `InternalOwnerId` as `0`, so it never recognized its own owned pawn (no local control), while the server was shipping `OwnerId=1`.

2. **`EntityClassData`** interpolated-first sort used `List<T>.Sort` (unstable) with no tie-break, so the relative order of equal-ranked fields is implementation-defined and can differ across .NET runtimes — independently re-introducing a cross-peer layout mismatch.

## Fix

Use **Ordinal** collation (`string.CompareOrdinal`) at both sites — culture-independent by construction and the correct comparison for code identifiers. The interpolated-first ranking is preserved; the Name comparison is only the tie-break.

```csharp
// Utils.GetProcessedFields
Array.Sort(fArr, (f1, f2) => string.CompareOrdinal(f1.Name, f2.Name));

// EntityClassData (interpolated-first sort)
if (wa != wb) return wb - wa;
return string.CompareOrdinal(a.Name, b.Name);
```

Behavior is unchanged for peers that share globalization settings; this only removes the divergence for peers that don't. No public API change.
